### PR TITLE
Enable syntax highlighting for emacs

### DIFF
--- a/justfile
+++ b/justfile
@@ -159,3 +159,6 @@ test:
 
 
 # vim: set ft=make textwidth=100 colorcolumn=101 noexpandtab sw=8 sts=8 ts=8 :
+# Local Variables:
+# mode: makefile
+# End:

--- a/justfile
+++ b/justfile
@@ -158,7 +158,8 @@ test:
 	#	  (And use clippy as a compiler plugin so we can save a pass)
 
 
-# vim: set ft=make textwidth=100 colorcolumn=101 noexpandtab sw=8 sts=8 ts=8 :
 # Local Variables:
 # mode: makefile
 # End:
+
+# vim: set ft=make textwidth=100 colorcolumn=101 noexpandtab sw=8 sts=8 ts=8 :


### PR DESCRIPTION
Adds a local variable block in the justfile to enable syntax highlighting under emacs.

PS This is a sweet project! I started doing [something similar](https://github.com/casey/boilerplate), but yours has many more features. Feel free to cannibalize anything you want from mine. It think the only things that yours is missing that mine has is a simple `.travis.yml`, as well as a bunch of convenience recipes.